### PR TITLE
Add getOrUndefined for possible out-of-bounds access

### DIFF
--- a/jquery3/src/main/scala/net/exoego/scalajs/jquery/JQuery.scala
+++ b/jquery3/src/main/scala/net/exoego/scalajs/jquery/JQuery.scala
@@ -311,6 +311,7 @@ trait JQuery[TElement] extends js.Iterable[TElement] {
   def focusout(handler: Boolean): this.type = js.native
   def focusout(): this.type = js.native
 
+  @JSName("get") def getOrUndefined(index: Int): js.UndefOr[TElement] = js.native
   def get(index: Int): TElement = js.native
   def get(): js.Array[TElement] = js.native
 


### PR DESCRIPTION
Addresses https://github.com/sjrd/scala-js-jquery/pull/63

[`get(index)` may return `undefined` when `index` is out of bounds](https://api.jquery.com/get/#get1), instead of throwing exception.
It is likely to use `index` that may out of bounds.

This PR adds `getOrUndefined ` as analogous to `Seq.headOption` or similar.