### PR TITLE
Mark members deprecated in jQuery 3.x

### DIFF
--- a/jquery3/src/main/scala/net/exoego/scalajs/jquery/JQuery.scala
+++ b/jquery3/src/main/scala/net/exoego/scalajs/jquery/JQuery.scala
@@ -89,23 +89,23 @@ trait JQuery[TElement] extends js.Iterable[TElement] {
   def before(contents: ContentLike*): this.type = js.native
   def before(function: js.ThisFunction2[TElement, Int, String, ContentLike]): this.type = js.native
 
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(eventType: String, eventData: js.Any, handler: JQuery.TypeEventHandler0[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(eventType: String, eventData: js.Any, handler: JQuery.TypeEventHandler1[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(eventType: String, eventData: js.Any, handler: JQuery.TypeEventHandler2[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(eventType: String, handler: JQuery.TypeEventHandler0[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(eventType: String, handler: JQuery.TypeEventHandler1[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(eventType: String, handler: JQuery.TypeEventHandler2[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(eventType: String, handler: js.UndefOr[Null]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(eventType: String, preventBubble: Boolean): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def bind(events: JQuery.TypeEventHandlers[TElement]): this.type = js.native
 
   def blur(eventData: js.Any, handler: JQuery.TypeEventHandler0[TElement]): this.type = js.native
@@ -186,21 +186,21 @@ trait JQuery[TElement] extends js.Iterable[TElement] {
   def delay(duration: JQuery.Duration, queueName: String): this.type = js.native
   def delay(duration: JQuery.Duration): this.type = js.native
 
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def delegate(selector: JQuery.Selector, eventType: String, eventData: js.Any, handler: JQuery.TypeEventHandler0[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def delegate(selector: JQuery.Selector, eventType: String, eventData: js.Any, handler: JQuery.TypeEventHandler1[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def delegate(selector: JQuery.Selector, eventType: String, eventData: js.Any, handler: JQuery.TypeEventHandler2[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def delegate(selector: JQuery.Selector, eventType: String, handler: JQuery.TypeEventHandler0[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def delegate(selector: JQuery.Selector, eventType: String, handler: JQuery.TypeEventHandler1[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def delegate(selector: JQuery.Selector, eventType: String, handler: JQuery.TypeEventHandler2[TElement]): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def delegate(selector: JQuery.Selector, eventType: String, handler: Boolean): this.type = js.native
-  @deprecated("Use on", "jQuery 3.0")
+  @deprecated("Use on", "jQuery 3.0.0")
   def delegate(selector: JQuery.Selector, events: JQuery.TypeEventHandlers[TElement]): this.type = js.native
 
   def dequeue(queueName: String): this.type = js.native
@@ -784,36 +784,36 @@ trait JQuery[TElement] extends js.Iterable[TElement] {
   def triggerHandler(event: JQuery.Event, extraParameters: js.Array[js.Any] | JQuery.PlainObject[js.Any]): js.Dynamic = js.native
   def triggerHandler(event: JQuery.Event): js.Dynamic = js.native
 
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def unbind(event: String, handler: JQuery.TypeEventHandler0[TElement]): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def unbind(event: String, handler: JQuery.TypeEventHandler1[TElement]): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def unbind(event: String, handler: JQuery.TypeEventHandler2[TElement]): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def unbind(event: String, handler: Boolean): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def unbind(event: String): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def unbind(event: JQuery.TriggeredEvent[TElement, js.Any, EventTarget, EventTarget]): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def unbind(): this.type = js.native
 
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def undelegate(selector: JQuery.Selector, eventType: String, handler: JQuery.TypeEventHandler0[TElement]): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def undelegate(selector: JQuery.Selector, eventType: String, handler: JQuery.TypeEventHandler1[TElement]): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def undelegate(selector: JQuery.Selector, eventType: String, handler: JQuery.TypeEventHandler2[TElement]): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def undelegate(selector: JQuery.Selector, eventType: String, handler: Boolean): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def undelegate(selector: JQuery.Selector, eventType: String): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def undelegate(selector: JQuery.Selector, events: JQuery.TypeEventHandlers[TElement]): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def undelegate(namespace: String): this.type = js.native
-  @deprecated("Use off", "jQuery 3.0")
+  @deprecated("Use off", "jQuery 3.0.0")
   def undelegate(): this.type = js.native
 
   def unwrap(selector: JQuery.Selector): this.type = js.native
@@ -934,7 +934,7 @@ object JQuery {
 
   @js.native
   trait Effects extends js.Object {
-    @deprecated("No longer needed in browsers that supports requestAnimationFrame", "jQuery 3.0")
+    @deprecated("No longer needed in browsers that supports requestAnimationFrame", "jQuery 3.0.0")
     var interval: Double = js.native
     var off: Boolean = js.native
     var step: PlainObject[AnimationHook[Node]] = js.native

--- a/jquery3/src/main/scala/net/exoego/scalajs/jquery/JQueryStatic.scala
+++ b/jquery3/src/main/scala/net/exoego/scalajs/jquery/JQueryStatic.scala
@@ -59,6 +59,7 @@ trait JQueryStatic extends js.Object {
 
   def ajaxTransport(dataType: String, handler: js.Function3[JQuery.AjaxSettings, JQuery.AjaxSettings, JQuery.jqXHR, JQuery.Transport | Unit]): Unit = js.native
 
+  @deprecated("Undocumented and used internally. Alternative not specified", "jQuery 3.3.0")
   def camelCase(value: String): String = js.native
 
   def contains(container: Element, contained: Element): Boolean = js.native
@@ -125,6 +126,7 @@ trait JQueryStatic extends js.Object {
 
   def hasData(element: Element | Document | Window | JQuery.PlainObject[_]): Boolean = js.native
 
+  @deprecated("Use jQuery.when(jQuery.ready, jQuery.Deferred(waitForMyDependencies))", "jQuery 3.2.0")
   def holdReady(hold: Boolean): Unit = js.native
 
   def htmlPrefilter(html: JQuery.htmlString): JQuery.htmlString = js.native
@@ -132,18 +134,20 @@ trait JQueryStatic extends js.Object {
   def inArray[T](value: T, array: js.Array[T], fromIndex: Int): Int = js.native
   def inArray[T](value: T, array: js.Array[T]): Int = js.native
 
+  @deprecated("Use Array.isArray", "jQuery 3.2.0")
   def isArray(obj: js.Any): Boolean = js.native
 
   def isEmptyObject(obj: js.Any): Boolean = js.native
 
-  @deprecated("Use typeof x === 'function'", "jQuery 3.3")
+  @deprecated("Use typeof x === 'function'", "jQuery 3.3.0")
   def isFunction(obj: js.Any): Boolean = js.native
 
+  @deprecated("Internal use only. Alternative not specified", "jQuery 3.3.0")
   def isNumeric(value: js.Any): Boolean = js.native
 
   def isPlainObject(obj: js.Any): Boolean = js.native
 
-  @deprecated("Alternative not specified", "jQuery 3.3")
+  @deprecated("Alternative not specified", "jQuery 3.3.0")
   def isWindow(obj: js.Any): Boolean = js.native
 
   def isXMLDoc(node: Node): Boolean = js.native
@@ -162,10 +166,12 @@ trait JQueryStatic extends js.Object {
   def noConflict(removeAll: Boolean): this.type = js.native
   def noConflict(): this.type = js.native
 
+  @deprecated("Undocumented. Alternative not specified", "jQuery 3.2.0")
   def nodeName(elem: Node, name: String): Boolean = js.native
 
   def noop(): Unit = js.native
 
+  @deprecated("Use Date.now", "jQuery 3.3.0")
   def now(): Double = js.native
 
   def param(obj: js.Array[JQuery.NameValuePair] | js.Object, traditional: Boolean): String = js.native
@@ -176,7 +182,7 @@ trait JQueryStatic extends js.Object {
   def parseHTML(data: String, keepScripts: Boolean): js.Array[JQuery.Node] = js.native
   def parseHTML(data: String): js.Array[JQuery.Node] = js.native
 
-  @deprecated("Use js.JSON.parse", "jQuery 3.0")
+  @deprecated("Use js.JSON.parse", "jQuery 3.0.0")
   def parseJSON(json: String): js.Dynamic = js.native
   def parseXML(data: String): js.Dynamic = js.native
 
@@ -189,138 +195,138 @@ trait JQueryStatic extends js.Object {
   def post(settings: JQuery.AjaxSettings): JQuery.jqXHR = js.native
   def post(): JQuery.jqXHR = js.native
 
-  def proxy[TReturn, A, B, C, D, E, F, G](funсtion: js.Function7[A, B, C, D, E, F, G, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function0[TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F](funсtion: js.Function6[A, B, C, D, E, F, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function0[TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E](funсtion: js.Function5[A, B, C, D, E, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function0[TReturn] = js.native
-  def proxy[TReturn, A, B, C, D](funсtion: js.Function4[A, B, C, D, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function0[TReturn] = js.native
-  def proxy[TReturn, A, B, C](funсtion: js.Function3[A, B, C, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function0[TReturn] = js.native
-  def proxy[TReturn, A, B](funсtion: js.Function2[A, B, TReturn], context: Null | Unit, a: A, b: B): js.Function0[TReturn] = js.native
-  def proxy[TReturn, A](funсtion: js.Function1[A, TReturn], context: Null | Unit, a: A): js.Function0[TReturn] = js.native
-  def proxy[TReturn](funсtion: js.Function0[TReturn], context: Null | Unit): js.Function0[TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, G, T](funсtion: js.Function8[A, B, C, D, E, F, G, T, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function1[T, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, T](funсtion: js.Function7[A, B, C, D, E, F, T, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function1[T, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, T](funсtion: js.Function6[A, B, C, D, E, T, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function1[T, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, T](funсtion: js.Function5[A, B, C, D, T, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function1[T, TReturn] = js.native
-  def proxy[TReturn, A, B, C, T](funсtion: js.Function4[A, B, C, T, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function1[T, TReturn] = js.native
-  def proxy[TReturn, A, B, T](funсtion: js.Function3[A, B, T, TReturn], context: Null | Unit, a: A, b: B): js.Function1[T, TReturn] = js.native
-  def proxy[TReturn, A, T](funсtion: js.Function2[A, T, TReturn], context: Null | Unit, a: A): js.Function1[T, TReturn] = js.native
-  def proxy[TReturn, T](funсtion: js.Function1[T, TReturn], context: Null | Unit): js.Function1[T, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, G, T, U](funсtion: js.Function9[A, B, C, D, E, F, G, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function2[T, U, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, T, U](funсtion: js.Function8[A, B, C, D, E, F, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function2[T, U, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, T, U](funсtion: js.Function7[A, B, C, D, E, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function2[T, U, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, T, U](funсtion: js.Function6[A, B, C, D, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function2[T, U, TReturn] = js.native
-  def proxy[TReturn, A, B, C, T, U](funсtion: js.Function5[A, B, C, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function2[T, U, TReturn] = js.native
-  def proxy[TReturn, A, B, T, U](funсtion: js.Function4[A, B, T, U, TReturn], context: Null | Unit, a: A, b: B): js.Function2[T, U, TReturn] = js.native
-  def proxy[TReturn, A, T, U](funсtion: js.Function3[A, T, U, TReturn], context: Null | Unit, a: A): js.Function2[T, U, TReturn] = js.native
-  def proxy[TReturn, T, U](funсtion: js.Function2[T, U, TReturn], context: Null | Unit): js.Function2[T, U, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, G, T, U, V](funсtion: js.Function10[A, B, C, D, E, F, G, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, T, U, V](funсtion: js.Function9[A, B, C, D, E, F, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, T, U, V](funсtion: js.Function8[A, B, C, D, E, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, T, U, V](funсtion: js.Function7[A, B, C, D, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TReturn, A, B, C, T, U, V](funсtion: js.Function6[A, B, C, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TReturn, A, B, T, U, V](funсtion: js.Function5[A, B, T, U, V, TReturn], context: Null | Unit, a: A, b: B): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TReturn, A, T, U, V](funсtion: js.Function4[A, T, U, V, TReturn], context: Null | Unit, a: A): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TReturn, T, U, V](funсtion: js.Function3[T, U, V, TReturn], context: Null | Unit): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, G, T, U, V, W](funсtion: js.Function11[A, B, C, D, E, F, G, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, T, U, V, W](funсtion: js.Function10[A, B, C, D, E, F, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, T, U, V, W](funсtion: js.Function9[A, B, C, D, E, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, T, U, V, W](funсtion: js.Function8[A, B, C, D, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TReturn, A, B, C, T, U, V, W](funсtion: js.Function7[A, B, C, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TReturn, A, B, T, U, V, W](funсtion: js.Function6[A, B, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TReturn, A, T, U, V, W](funсtion: js.Function5[A, T, U, V, W, TReturn], context: Null | Unit, a: A): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TReturn, T, U, V, W](funсtion: js.Function4[T, U, V, W, TReturn], context: Null | Unit): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, G, T, U, V, W, X](funсtion: js.Function12[A, B, C, D, E, F, G, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, T, U, V, W, X](funсtion: js.Function11[A, B, C, D, E, F, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, T, U, V, W, X](funсtion: js.Function10[A, B, C, D, E, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, T, U, V, W, X](funсtion: js.Function9[A, B, C, D, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TReturn, A, B, C, T, U, V, W, X](funсtion: js.Function8[A, B, C, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TReturn, A, B, T, U, V, W, X](funсtion: js.Function7[A, B, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TReturn, A, T, U, V, W, X](funсtion: js.Function6[A, T, U, V, W, X, TReturn], context: Null | Unit, a: A): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TReturn, T, U, V, W, X](funсtion: js.Function5[T, U, V, W, X, TReturn], context: Null | Unit): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, G, T, U, V, W, X, Y](funсtion: js.Function13[A, B, C, D, E, F, G, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, T, U, V, W, X, Y](funсtion: js.Function12[A, B, C, D, E, F, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, T, U, V, W, X, Y](funсtion: js.Function11[A, B, C, D, E, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, T, U, V, W, X, Y](funсtion: js.Function10[A, B, C, D, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TReturn, A, B, C, T, U, V, W, X, Y](funсtion: js.Function9[A, B, C, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TReturn, A, B, T, U, V, W, X, Y](funсtion: js.Function8[A, B, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TReturn, A, T, U, V, W, X, Y](funсtion: js.Function7[A, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TReturn, T, U, V, W, X, Y](funсtion: js.Function6[T, U, V, W, X, Y, TReturn], context: Null | Unit): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, G, T, U, V, W, X, Y, Z](funсtion: js.Function14[A, B, C, D, E, F, G, T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, F, T, U, V, W, X, Y, Z](funсtion: js.Function13[A, B, C, D, E, F,  T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, E, T, U, V, W, X, Y, Z](funсtion: js.Function12[A, B, C, D, E, T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TReturn, A, B, C, D, T, U, V, W, X, Y, Z](funсtion: js.Function11[A, B, C, D,  T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TReturn, A, B, C, T, U, V, W, X, Y, Z](funсtion: js.Function10[A, B, C, T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TReturn, A, B, T, U, V, W, X, Y, Z](funсtion: js.Function9[A, B,  T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TReturn, A, T, U, V, W, X, Y, Z](funсtion: js.Function8[A,  T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TReturn, T, U, V, W, X, Y, Z](funсtion: js.Function7[T, U, V, W, X, Y, Z, TReturn], context: Null | Unit): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TReturn](funсtion: js.Function, context: Null | Unit, additionalArguments: js.Any*): js.Function = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, G](funсtion: js.Function7[A, B, C, D, E, F, G, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F](funсtion: js.Function6[A, B, C, D, E, F, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E](funсtion: js.Function5[A, B, C, D, E, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D](funсtion: js.Function4[A, B, C, D, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C](funсtion: js.Function3[A, B, C, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B](funсtion: js.Function2[A, B, TReturn], context: Null | Unit, a: A, b: B): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A](funсtion: js.Function1[A, TReturn], context: Null | Unit, a: A): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn](funсtion: js.Function0[TReturn], context: Null | Unit): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, G, T](funсtion: js.Function8[A, B, C, D, E, F, G, T, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, T](funсtion: js.Function7[A, B, C, D, E, F, T, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, T](funсtion: js.Function6[A, B, C, D, E, T, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, T](funсtion: js.Function5[A, B, C, D, T, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, T](funсtion: js.Function4[A, B, C, T, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, T](funсtion: js.Function3[A, B, T, TReturn], context: Null | Unit, a: A, b: B): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, T](funсtion: js.Function2[A, T, TReturn], context: Null | Unit, a: A): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, T](funсtion: js.Function1[T, TReturn], context: Null | Unit): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, G, T, U](funсtion: js.Function9[A, B, C, D, E, F, G, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, T, U](funсtion: js.Function8[A, B, C, D, E, F, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, T, U](funсtion: js.Function7[A, B, C, D, E, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, T, U](funсtion: js.Function6[A, B, C, D, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, T, U](funсtion: js.Function5[A, B, C, T, U, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, T, U](funсtion: js.Function4[A, B, T, U, TReturn], context: Null | Unit, a: A, b: B): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, T, U](funсtion: js.Function3[A, T, U, TReturn], context: Null | Unit, a: A): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, T, U](funсtion: js.Function2[T, U, TReturn], context: Null | Unit): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, G, T, U, V](funсtion: js.Function10[A, B, C, D, E, F, G, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, T, U, V](funсtion: js.Function9[A, B, C, D, E, F, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, T, U, V](funсtion: js.Function8[A, B, C, D, E, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, T, U, V](funсtion: js.Function7[A, B, C, D, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, T, U, V](funсtion: js.Function6[A, B, C, T, U, V, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, T, U, V](funсtion: js.Function5[A, B, T, U, V, TReturn], context: Null | Unit, a: A, b: B): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, T, U, V](funсtion: js.Function4[A, T, U, V, TReturn], context: Null | Unit, a: A): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, T, U, V](funсtion: js.Function3[T, U, V, TReturn], context: Null | Unit): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, G, T, U, V, W](funсtion: js.Function11[A, B, C, D, E, F, G, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, T, U, V, W](funсtion: js.Function10[A, B, C, D, E, F, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, T, U, V, W](funсtion: js.Function9[A, B, C, D, E, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, T, U, V, W](funсtion: js.Function8[A, B, C, D, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, T, U, V, W](funсtion: js.Function7[A, B, C, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, T, U, V, W](funсtion: js.Function6[A, B, T, U, V, W, TReturn], context: Null | Unit, a: A, b: B): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, T, U, V, W](funсtion: js.Function5[A, T, U, V, W, TReturn], context: Null | Unit, a: A): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, T, U, V, W](funсtion: js.Function4[T, U, V, W, TReturn], context: Null | Unit): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, G, T, U, V, W, X](funсtion: js.Function12[A, B, C, D, E, F, G, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, T, U, V, W, X](funсtion: js.Function11[A, B, C, D, E, F, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, T, U, V, W, X](funсtion: js.Function10[A, B, C, D, E, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, T, U, V, W, X](funсtion: js.Function9[A, B, C, D, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, T, U, V, W, X](funсtion: js.Function8[A, B, C, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, T, U, V, W, X](funсtion: js.Function7[A, B, T, U, V, W, X, TReturn], context: Null | Unit, a: A, b: B): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, T, U, V, W, X](funсtion: js.Function6[A, T, U, V, W, X, TReturn], context: Null | Unit, a: A): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, T, U, V, W, X](funсtion: js.Function5[T, U, V, W, X, TReturn], context: Null | Unit): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, G, T, U, V, W, X, Y](funсtion: js.Function13[A, B, C, D, E, F, G, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, T, U, V, W, X, Y](funсtion: js.Function12[A, B, C, D, E, F, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, T, U, V, W, X, Y](funсtion: js.Function11[A, B, C, D, E, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, T, U, V, W, X, Y](funсtion: js.Function10[A, B, C, D, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, T, U, V, W, X, Y](funсtion: js.Function9[A, B, C, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, T, U, V, W, X, Y](funсtion: js.Function8[A, B, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A, b: B): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, T, U, V, W, X, Y](funсtion: js.Function7[A, T, U, V, W, X, Y, TReturn], context: Null | Unit, a: A): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, T, U, V, W, X, Y](funсtion: js.Function6[T, U, V, W, X, Y, TReturn], context: Null | Unit): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, G, T, U, V, W, X, Y, Z](funсtion: js.Function14[A, B, C, D, E, F, G, T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, F, T, U, V, W, X, Y, Z](funсtion: js.Function13[A, B, C, D, E, F,  T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E, f: F): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, E, T, U, V, W, X, Y, Z](funсtion: js.Function12[A, B, C, D, E, T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D, e: E): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, D, T, U, V, W, X, Y, Z](funсtion: js.Function11[A, B, C, D,  T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C, d: D): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, C, T, U, V, W, X, Y, Z](funсtion: js.Function10[A, B, C, T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B, c: C): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, B, T, U, V, W, X, Y, Z](funсtion: js.Function9[A, B,  T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A, b: B): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, A, T, U, V, W, X, Y, Z](funсtion: js.Function8[A,  T, U, V, W, X, Y, Z, TReturn], context: Null | Unit, a: A): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn, T, U, V, W, X, Y, Z](funсtion: js.Function7[T, U, V, W, X, Y, Z, TReturn], context: Null | Unit): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TReturn](funсtion: js.Function, context: Null | Unit, additionalArguments: js.Any*): js.Function = js.native
 
-  def proxy[TContext, TReturn, A, B, C, D, E, F, G](funсtion: js.ThisFunction7[TContext, A, B, C, D, E, F, G, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function0[TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F](funсtion: js.ThisFunction6[TContext, A, B, C, D, E, F, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function0[TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E](funсtion: js.ThisFunction5[TContext, A, B, C, D, E, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function0[TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D](funсtion: js.ThisFunction4[TContext, A, B, C, D, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function0[TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C](funсtion: js.ThisFunction3[TContext, A, B, C, TReturn], context: TContext, a: A, b: B, c: C): js.Function0[TReturn] = js.native
-  def proxy[TContext, TReturn, A, B](funсtion: js.ThisFunction2[TContext, A, B, TReturn], context: TContext, a: A, b: B): js.Function0[TReturn] = js.native
-  def proxy[TContext, TReturn, A](funсtion: js.ThisFunction1[TContext, A, TReturn], context: TContext, a: A): js.Function0[TReturn] = js.native
-  def proxy[TContext, TReturn](funсtion: js.ThisFunction0[TContext, TReturn], context: TContext): js.Function0[TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, G, T](funсtion: js.ThisFunction8[TContext, A, B, C, D, E, F, G, T, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function1[T, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, T](funсtion: js.ThisFunction7[TContext, A, B, C, D, E, F, T, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function1[T, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, T](funсtion: js.ThisFunction6[TContext, A, B, C, D, E, T, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function1[T, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, T](funсtion: js.ThisFunction5[TContext, A, B, C, D, T, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function1[T, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, T](funсtion: js.ThisFunction4[TContext, A, B, C, T, TReturn], context: TContext, a: A, b: B, c: C): js.Function1[T, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, T](funсtion: js.ThisFunction3[TContext, A, B, T, TReturn], context: TContext, a: A, b: B): js.Function1[T, TReturn] = js.native
-  def proxy[TContext, TReturn, A, T](funсtion: js.ThisFunction2[TContext, A, T, TReturn], context: TContext, a: A): js.Function1[T, TReturn] = js.native
-  def proxy[TContext, TReturn, T](funсtion: js.ThisFunction1[TContext, T, TReturn], context: TContext): js.Function1[T, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U](funсtion: js.ThisFunction9[TContext, A, B, C, D, E, F, G, T, U, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function2[T, U, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, T, U](funсtion: js.ThisFunction8[TContext, A, B, C, D, E, F, T, U, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function2[T, U, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, T, U](funсtion: js.ThisFunction7[TContext, A, B, C, D, E, T, U, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function2[T, U, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, T, U](funсtion: js.ThisFunction6[TContext, A, B, C, D, T, U, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function2[T, U, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, T, U](funсtion: js.ThisFunction5[TContext, A, B, C, T, U, TReturn], context: TContext, a: A, b: B, c: C): js.Function2[T, U, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, T, U](funсtion: js.ThisFunction4[TContext, A, B, T, U, TReturn], context: TContext, a: A, b: B): js.Function2[T, U, TReturn] = js.native
-  def proxy[TContext, TReturn, A, T, U](funсtion: js.ThisFunction3[TContext, A, T, U, TReturn], context: TContext, a: A): js.Function2[T, U, TReturn] = js.native
-  def proxy[TContext, TReturn, T, U](funсtion: js.ThisFunction2[TContext, T, U, TReturn], context: TContext): js.Function2[T, U, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V](funсtion: js.ThisFunction10[TContext, A, B, C, D, E, F, G, T, U, V, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V](funсtion: js.ThisFunction9[TContext, A, B, C, D, E, F, T, U, V, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, T, U, V](funсtion: js.ThisFunction8[TContext, A, B, C, D, E, T, U, V, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, T, U, V](funсtion: js.ThisFunction7[TContext, A, B, C, D, T, U, V, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, T, U, V](funсtion: js.ThisFunction6[TContext, A, B, C, T, U, V, TReturn], context: TContext, a: A, b: B, c: C): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, T, U, V](funсtion: js.ThisFunction5[TContext, A, B, T, U, V, TReturn], context: TContext, a: A, b: B): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TContext, TReturn, A, T, U, V](funсtion: js.ThisFunction4[TContext, A, T, U, V, TReturn], context: TContext, a: A): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TContext, TReturn, T, U, V](funсtion: js.ThisFunction3[TContext, T, U, V, TReturn], context: TContext): js.Function3[T, U, V, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V, W](funсtion: js.ThisFunction11[TContext, A, B, C, D, E, F, G, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V, W](funсtion: js.ThisFunction10[TContext, A, B, C, D, E, F, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, T, U, V, W](funсtion: js.ThisFunction9[TContext, A, B, C, D, E, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, T, U, V, W](funсtion: js.ThisFunction8[TContext, A, B, C, D, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, T, U, V, W](funсtion: js.ThisFunction7[TContext, A, B, C, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, T, U, V, W](funсtion: js.ThisFunction6[TContext, A, B, T, U, V, W, TReturn], context: TContext, a: A, b: B): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TContext, TReturn, A, T, U, V, W](funсtion: js.ThisFunction5[TContext, A, T, U, V, W, TReturn], context: TContext, a: A): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TContext, TReturn, T, U, V, W](funсtion: js.ThisFunction4[TContext, T, U, V, W, TReturn], context: TContext): js.Function4[T, U, V, W, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V, W, X](funсtion: js.ThisFunction12[TContext, A, B, C, D, E, F, G, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V, W, X](funсtion: js.ThisFunction11[TContext, A, B, C, D, E, F, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, T, U, V, W, X](funсtion: js.ThisFunction10[TContext, A, B, C, D, E, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, T, U, V, W, X](funсtion: js.ThisFunction9[TContext, A, B, C, D, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, T, U, V, W, X](funсtion: js.ThisFunction8[TContext, A, B, C, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, T, U, V, W, X](funсtion: js.ThisFunction7[TContext, A, B, T, U, V, W, X, TReturn], context: TContext, a: A, b: B): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TContext, TReturn, A, T, U, V, W, X](funсtion: js.ThisFunction6[TContext, A, T, U, V, W, X, TReturn], context: TContext, a: A): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TContext, TReturn, T, U, V, W, X](funсtion: js.ThisFunction5[TContext, T, U, V, W, X, TReturn], context: TContext): js.Function5[T, U, V, W, X, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V, W, X, Y](funсtion: js.ThisFunction13[TContext, A, B, C, D, E, F, G, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V, W, X, Y](funсtion: js.ThisFunction12[TContext, A, B, C, D, E, F, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, T, U, V, W, X, Y](funсtion: js.ThisFunction11[TContext, A, B, C, D, E, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, T, U, V, W, X, Y](funсtion: js.ThisFunction10[TContext, A, B, C, D, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, T, U, V, W, X, Y](funсtion: js.ThisFunction9[TContext, A, B, C, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, T, U, V, W, X, Y](funсtion: js.ThisFunction8[TContext, A, B, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TContext, TReturn, A, T, U, V, W, X, Y](funсtion: js.ThisFunction7[TContext, A, T, U, V, W, X, Y, TReturn], context: TContext, a: A): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TContext, TReturn, T, U, V, W, X, Y](funсtion: js.ThisFunction6[TContext, T, U, V, W, X, Y, TReturn], context: TContext): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction14[TContext, A, B, C, D, E, F, G, T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction13[TContext, A, B, C, D, E, F, T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, E, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction12[TContext, A, B, C, D, E,  T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, D, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction11[TContext, A, B, C, D,  T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, C, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction10[TContext, A, B, C,  T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TContext, TReturn, A, B, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction9[TContext, A, B,  T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TContext, TReturn, A, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction8[TContext, A, T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TContext, TReturn, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction7[TContext, T, U, V, W, X, Y, Z,TReturn], context: TContext): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
-  def proxy[TContext, TReturn](funсtion: js.Function, context: TContext, additionalArguments: js.Any*): js.Function = js.native
-  def proxy[TContext](context: TContext, name: String, additionalArguments: js.Any*): js.Function = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, G](funсtion: js.ThisFunction7[TContext, A, B, C, D, E, F, G, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F](funсtion: js.ThisFunction6[TContext, A, B, C, D, E, F, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E](funсtion: js.ThisFunction5[TContext, A, B, C, D, E, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D](funсtion: js.ThisFunction4[TContext, A, B, C, D, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C](funсtion: js.ThisFunction3[TContext, A, B, C, TReturn], context: TContext, a: A, b: B, c: C): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B](funсtion: js.ThisFunction2[TContext, A, B, TReturn], context: TContext, a: A, b: B): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A](funсtion: js.ThisFunction1[TContext, A, TReturn], context: TContext, a: A): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn](funсtion: js.ThisFunction0[TContext, TReturn], context: TContext): js.Function0[TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, G, T](funсtion: js.ThisFunction8[TContext, A, B, C, D, E, F, G, T, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, T](funсtion: js.ThisFunction7[TContext, A, B, C, D, E, F, T, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, T](funсtion: js.ThisFunction6[TContext, A, B, C, D, E, T, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, T](funсtion: js.ThisFunction5[TContext, A, B, C, D, T, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, T](funсtion: js.ThisFunction4[TContext, A, B, C, T, TReturn], context: TContext, a: A, b: B, c: C): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, T](funсtion: js.ThisFunction3[TContext, A, B, T, TReturn], context: TContext, a: A, b: B): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, T](funсtion: js.ThisFunction2[TContext, A, T, TReturn], context: TContext, a: A): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, T](funсtion: js.ThisFunction1[TContext, T, TReturn], context: TContext): js.Function1[T, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U](funсtion: js.ThisFunction9[TContext, A, B, C, D, E, F, G, T, U, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, T, U](funсtion: js.ThisFunction8[TContext, A, B, C, D, E, F, T, U, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, T, U](funсtion: js.ThisFunction7[TContext, A, B, C, D, E, T, U, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, T, U](funсtion: js.ThisFunction6[TContext, A, B, C, D, T, U, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, T, U](funсtion: js.ThisFunction5[TContext, A, B, C, T, U, TReturn], context: TContext, a: A, b: B, c: C): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, T, U](funсtion: js.ThisFunction4[TContext, A, B, T, U, TReturn], context: TContext, a: A, b: B): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, T, U](funсtion: js.ThisFunction3[TContext, A, T, U, TReturn], context: TContext, a: A): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, T, U](funсtion: js.ThisFunction2[TContext, T, U, TReturn], context: TContext): js.Function2[T, U, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V](funсtion: js.ThisFunction10[TContext, A, B, C, D, E, F, G, T, U, V, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V](funсtion: js.ThisFunction9[TContext, A, B, C, D, E, F, T, U, V, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, T, U, V](funсtion: js.ThisFunction8[TContext, A, B, C, D, E, T, U, V, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, T, U, V](funсtion: js.ThisFunction7[TContext, A, B, C, D, T, U, V, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, T, U, V](funсtion: js.ThisFunction6[TContext, A, B, C, T, U, V, TReturn], context: TContext, a: A, b: B, c: C): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, T, U, V](funсtion: js.ThisFunction5[TContext, A, B, T, U, V, TReturn], context: TContext, a: A, b: B): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, T, U, V](funсtion: js.ThisFunction4[TContext, A, T, U, V, TReturn], context: TContext, a: A): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, T, U, V](funсtion: js.ThisFunction3[TContext, T, U, V, TReturn], context: TContext): js.Function3[T, U, V, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V, W](funсtion: js.ThisFunction11[TContext, A, B, C, D, E, F, G, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V, W](funсtion: js.ThisFunction10[TContext, A, B, C, D, E, F, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, T, U, V, W](funсtion: js.ThisFunction9[TContext, A, B, C, D, E, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, T, U, V, W](funсtion: js.ThisFunction8[TContext, A, B, C, D, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, T, U, V, W](funсtion: js.ThisFunction7[TContext, A, B, C, T, U, V, W, TReturn], context: TContext, a: A, b: B, c: C): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, T, U, V, W](funсtion: js.ThisFunction6[TContext, A, B, T, U, V, W, TReturn], context: TContext, a: A, b: B): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, T, U, V, W](funсtion: js.ThisFunction5[TContext, A, T, U, V, W, TReturn], context: TContext, a: A): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, T, U, V, W](funсtion: js.ThisFunction4[TContext, T, U, V, W, TReturn], context: TContext): js.Function4[T, U, V, W, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V, W, X](funсtion: js.ThisFunction12[TContext, A, B, C, D, E, F, G, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V, W, X](funсtion: js.ThisFunction11[TContext, A, B, C, D, E, F, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, T, U, V, W, X](funсtion: js.ThisFunction10[TContext, A, B, C, D, E, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, T, U, V, W, X](funсtion: js.ThisFunction9[TContext, A, B, C, D, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, T, U, V, W, X](funсtion: js.ThisFunction8[TContext, A, B, C, T, U, V, W, X, TReturn], context: TContext, a: A, b: B, c: C): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, T, U, V, W, X](funсtion: js.ThisFunction7[TContext, A, B, T, U, V, W, X, TReturn], context: TContext, a: A, b: B): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, T, U, V, W, X](funсtion: js.ThisFunction6[TContext, A, T, U, V, W, X, TReturn], context: TContext, a: A): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, T, U, V, W, X](funсtion: js.ThisFunction5[TContext, T, U, V, W, X, TReturn], context: TContext): js.Function5[T, U, V, W, X, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V, W, X, Y](funсtion: js.ThisFunction13[TContext, A, B, C, D, E, F, G, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V, W, X, Y](funсtion: js.ThisFunction12[TContext, A, B, C, D, E, F, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, T, U, V, W, X, Y](funсtion: js.ThisFunction11[TContext, A, B, C, D, E, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, T, U, V, W, X, Y](funсtion: js.ThisFunction10[TContext, A, B, C, D, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, T, U, V, W, X, Y](funсtion: js.ThisFunction9[TContext, A, B, C, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B, c: C): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, T, U, V, W, X, Y](funсtion: js.ThisFunction8[TContext, A, B, T, U, V, W, X, Y, TReturn], context: TContext, a: A, b: B): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, T, U, V, W, X, Y](funсtion: js.ThisFunction7[TContext, A, T, U, V, W, X, Y, TReturn], context: TContext, a: A): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, T, U, V, W, X, Y](funсtion: js.ThisFunction6[TContext, T, U, V, W, X, Y, TReturn], context: TContext): js.Function6[T, U, V, W, X, Y, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, G, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction14[TContext, A, B, C, D, E, F, G, T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, F, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction13[TContext, A, B, C, D, E, F, T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E, f: F): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, E, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction12[TContext, A, B, C, D, E,  T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C, d: D, e: E): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, D, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction11[TContext, A, B, C, D,  T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C, d: D): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, C, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction10[TContext, A, B, C,  T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B, c: C): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, B, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction9[TContext, A, B,  T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A, b: B): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, A, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction8[TContext, A, T, U, V, W, X, Y, Z,TReturn], context: TContext, a: A): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn, T, U, V, W, X, Y, Z](funсtion: js.ThisFunction7[TContext, T, U, V, W, X, Y, Z,TReturn], context: TContext): js.Function7[T, U, V, W, X, Y, Z, TReturn] = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext, TReturn](funсtion: js.Function, context: TContext, additionalArguments: js.Any*): js.Function = js.native
+  @deprecated("Use Function.bind", "jQuery 3.3.0") def proxy[TContext](context: TContext, name: String, additionalArguments: js.Any*): js.Function = js.native
 
   def queue[T <: Element](element: T, queueName: String, data: JQuery.TypeOrArray[JQuery.QueueFunction[T]]): JQuery.Queue[T] = js.native
   def queue[T <: Element](element: T, data: JQuery.TypeOrArray[JQuery.QueueFunction[T]]): JQuery.Queue[T] = js.native
@@ -342,9 +348,10 @@ trait JQueryStatic extends js.Object {
 
   def trim(str: String): String = js.native
 
+  @deprecated("Undocumented and internal use only. Alternative not specified", "jQuery 3.3.0")
   def `type`(obj: js.Any): String = js.native
 
-  @deprecated("Use uniqueSort", "jQuery 3.0")
+  @deprecated("Use uniqueSort", "jQuery 3.0.0")
   def unique[T <: Element](array: js.Array[T]): js.Array[T] = js.native
   def uniqueSort[T <: Element](array: js.Array[T]): js.Array[T] = js.native
 


### PR DESCRIPTION
* https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/
* https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/
* https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/

Event shorthands (e.g. `.hover` or `.click) are also "deprecated" in jQuery 3.3.0 to encourage use of `on` / `trigger`, but it is unlikely to be removed in jQuery 4.x.
So not marked in this PR.