### PR TITLE
[jQuery 3.5.x+] Add even/odd method that replace the deprecated :even/:odd selectors

### DIFF
--- a/jquery3/src/main/scala/net/exoego/scalajs/jquery/JQuery.scala
+++ b/jquery3/src/main/scala/net/exoego/scalajs/jquery/JQuery.scala
@@ -844,6 +844,9 @@ trait JQuery[TElement] extends js.Iterable[TElement] {
 
   @JSBracketAccess
   def update(n: Int, v: TElement): Unit = js.native
+
+  def even(): this.type = js.native
+  def odd(): this.type = js.native
 }
 
 


### PR DESCRIPTION
> https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/
> Specifically, we’ve added the .even() and .odd() methods to replace the :even and :odd selectors. With these methods in place, we can safely remove these overly complicated selectors in jQuery 4.0.

